### PR TITLE
feat: add in appointments endpoint for patient dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ app.register_blueprint(patient_dashboard_bp)
 app.register_blueprint(patient_dashboard_payments_bp)
 app.register_blueprint(patient_dashboard_appointments_bp)
 
+
 # First route!
 @app.route('/api/hello', methods=['GET'])
 def hello():

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from config import DB_CONFIG
 from blueprints.registration import registration_bp
 from blueprints.patientDashboard import patient_dashboard_bp
 from blueprints.patientDashboardPayments import patient_dashboard_payments_bp
+from blueprints.patientDashboardAppointments import patient_dashboard_appointments_bp
 
 app = Flask(__name__)
 CORS(app)
@@ -12,7 +13,7 @@ CORS(app)
 app.register_blueprint(registration_bp)
 app.register_blueprint(patient_dashboard_bp)
 app.register_blueprint(patient_dashboard_payments_bp)
-
+app.register_blueprint(patient_dashboard_appointments_bp)
 
 # First route!
 @app.route('/api/hello', methods=['GET'])

--- a/blueprints/patientDashboardAppointments.py
+++ b/blueprints/patientDashboardAppointments.py
@@ -1,0 +1,51 @@
+from flask import Blueprint, jsonify, request
+import mysql.connector
+from config import DB_CONFIG
+
+patient_dashboard_appointments_bp = Blueprint('patient_dashboard_appointments', __name__, url_prefix='/api/patient-dashboard/appointments')
+
+@patient_dashboard_appointments_bp.route('/', methods=['GET'])
+def get_appointments():
+    """
+    Endpoint to fetch current (upcoming) and previous (past) appointments for a given patient.
+    Expects a query parameter `patient_id`.
+    Returns a JSON object with two keys: "upcoming" and "past".
+    """
+    patient_id = request.args.get('patient_id', type=int)
+    if not patient_id:
+        return jsonify({"error": "patient_id query parameter is required"}), 400
+
+    try:
+        connection = mysql.connector.connect(**DB_CONFIG)
+        cursor = connection.cursor(dictionary=True)
+
+        # Fetch upcoming appointments (appointments that have not yet occurred)
+        upcoming_sql = """
+            SELECT appointment_id, doctor_id, patient_id, appointment_time, status
+            FROM appointments
+            WHERE patient_id = %s AND appointment_time >= NOW()
+            ORDER BY appointment_time ASC
+        """
+        cursor.execute(upcoming_sql, (patient_id,))
+        upcoming_appointments = cursor.fetchall()
+
+        # Fetch past appointments (appointments that have already occurred)
+        past_sql = """
+            SELECT appointment_id, doctor_id, patient_id, appointment_time, status
+            FROM appointments
+            WHERE patient_id = %s AND appointment_time < NOW()
+            ORDER BY appointment_time DESC
+        """
+        cursor.execute(past_sql, (patient_id,))
+        past_appointments = cursor.fetchall()
+
+        cursor.close()
+        connection.close()
+
+        return jsonify({
+            "upcoming": upcoming_appointments,
+            "past": past_appointments
+        }), 200
+
+    except mysql.connector.Error as err:
+        return jsonify({"error": str(err)}), 500

--- a/blueprints/patientDashboardAppointments.py
+++ b/blueprints/patientDashboardAppointments.py
@@ -4,6 +4,7 @@ from config import DB_CONFIG
 
 patient_dashboard_appointments_bp = Blueprint('patient_dashboard_appointments', __name__, url_prefix='/api/patient-dashboard/appointments')
 
+
 @patient_dashboard_appointments_bp.route('/', methods=['GET'])
 def get_appointments():
     """


### PR DESCRIPTION
## Changes Made
<!-- Briefly describe what you changed and why -->
Add in the appointments endpoint, queried with a patient_id number
returns
- Past appointments list
- future appointments list

## Testing Done
<!-- Outline how you tested your changes, including any manual steps or automated tests -->
Curl

## Does Anyone Else Need to Know About This Change?
<!-- Tag team members, mention documentation updates, or call out dependencies if applicable -->
 - [x] #daily-updates on discord